### PR TITLE
chore: use PROJECT_SOURCE instead of PROJECTS_ROOT

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -4,14 +4,15 @@ metadata:
 components:
   - name: tools
     container:
-      image: quay.io/devfile/universal-developer-image:ubi8-latest 
+      image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
       memoryLimit: 3Gi
+
 commands:
   - id: run-main-script
     exec:
       label: "Run main.sh script"
       component: tools
-      workingDir: '${PROJECTS_ROOT}/bash'
+      workingDir: '${PROJECT_SOURCE}'
       commandLine: |
         ./main.sh
       group:


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

- Replaces PROJECTS_ROOT environment variable on PROJECT_SOURCE in devfile command
- Bumps to the specific tag of universal developer image