### PR TITLE
chore: set devfile schemaVersion: 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: bash
 components:


### PR DESCRIPTION
Set devfile schemaVersion: 2.2.2

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2024 01 31-15_21_32](https://github.com/che-samples/bash/assets/1271546/6b9cbc76-61c1-4d20-a2a8-0066bd995f9e)

Related issue: https://github.com/eclipse/che/issues/21985

